### PR TITLE
Fix crashes caused by non-zeroing weak references

### DIFF
--- a/FRZHTTPImageCache/UIImageView+FRZHTTPImageCache.m
+++ b/FRZHTTPImageCache/UIImageView+FRZHTTPImageCache.m
@@ -137,14 +137,4 @@
     return self.weakOperationWrapper.currentFetchOperation;
 }
 
-- (void)setTransformBlock:(UIImage *(^)(UIImage *))transformBlock
-{
-    objc_setAssociatedObject(self, @selector(transformBlock), transformBlock, OBJC_ASSOCIATION_COPY_NONATOMIC);
-}
-
-- (UIImage *(^)(UIImage *))transformBlock
-{
-    return objc_getAssociatedObject(self, @selector(transformBlock));
-}
-
 @end


### PR DESCRIPTION
## Changes

TIL **objc associated object does NOT support zeroing weak references** 

- Created a `WeakOperationWrapper` that is stored `strong` using associated object
- Change `currentFetchOperation` underlying implementation to use `WeakOperationWrapper` instead of associated object

More Info: https://stackoverflow.com/a/27035233

## Crash Report
http://crashes.to/s/705e2388848