### PR TITLE
immediately return images from memory cache

### DIFF
--- a/FRZHTTPImageCache/FRZImageCacheManager.h
+++ b/FRZHTTPImageCache/FRZImageCacheManager.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable FRZImageCacheEntry *)fetchImageForURL:(NSURL *)URL;
 - (void)cacheImage:(nullable UIImage *)image forURLResponse:(NSHTTPURLResponse *)response;
 
+- (nullable FRZImageCacheEntry *)memoryCachedImageForURL:(NSURL *)URL;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FRZHTTPImageCache/FRZImageCacheManager.m
+++ b/FRZHTTPImageCache/FRZImageCacheManager.m
@@ -85,12 +85,17 @@ static FRZImageCacheManager *sharedInstance = nil;
 
 - (nullable FRZImageCacheEntry *)fetchImageForURL:(NSURL *)URL
 {
-    FRZImageCacheEntry *cachedImage = [self.memoryCache objectForKey:[self keyForURL:URL]];
+    FRZImageCacheEntry *cachedImage = [self memoryCachedImageForURL:URL];
     if (cachedImage) {
         [FRZHTTPImageCache.logger frz_logMessage:@"Returning image from memory cache" forImageURL:cachedImage.originalResponse.URL logLevel:FRZHTTPImageCacheLogLevelVerbose];
         return cachedImage;
     }
     return [self diskCachedImageForURL:URL];
+}
+
+- (nullable FRZImageCacheEntry *)memoryCachedImageForURL:(NSURL *)URL
+{
+    return [self.memoryCache objectForKey:[self keyForURL:URL]];
 }
 
 - (FRZImageCacheEntry *)diskCachedImageForURL:(NSURL *)URL

--- a/FRZHTTPImageCache/UIImageView+FRZHTTPImageCache.m
+++ b/FRZHTTPImageCache/UIImageView+FRZHTTPImageCache.m
@@ -8,6 +8,7 @@
 
 #import "UIImageView+FRZHTTPImageCache.h"
 #import "FRZImageFetchOperation.h"
+#import "FRZImageCacheManager.h"
 #import <objc/runtime.h>
 
 @interface UIImageView (FRZHTTPImageCacheInternal)
@@ -38,7 +39,12 @@
         }
         return;
     }
-
+    
+    FRZImageCacheEntry *memoryCacheEntry = [[FRZImageCacheManager sharedInstance] memoryCachedImageForURL:URL];
+    if (memoryCacheEntry.image != nil) {
+        self.image = memoryCacheEntry.image;
+    }
+    
     FRZImageFetchOperation *fetchOperation = [[FRZImageFetchOperation alloc] initWithURL:URL];
     self.currentFetchOperation = fetchOperation;
     fetchOperation.delegate = self;


### PR DESCRIPTION
@accatyyc thoughts on this strategy for avoiding the flicker? (pull request to allow discussion, commit can be fast-forwarded rather than merged)

---

there is always a short delay when fetching images, even when the image is in the memory cache. this is due to the image being fetched using an operation (so jumping back and forth between threads).

this commit keeps the existing operation intact (allowing it to handle the complex logic such as HTTP, disk cache, etc), but fetches the image from the memory cache in the UIImageView extension.

note: the memory cache is hit twice